### PR TITLE
operator string_view()

### DIFF
--- a/include/boost/url/const_string.hpp
+++ b/include/boost/url/const_string.hpp
@@ -13,6 +13,10 @@
 
 #include <boost/url/detail/config.hpp>
 #include <boost/url/string_view.hpp>
+#include <boost/url/detail/except.hpp>
+#ifndef BOOST_URL_NO_CXX17_HDR_STRING_VIEW
+#include <string_view>
+#endif
 
 namespace boost {
 namespace urls {
@@ -28,24 +32,15 @@ namespace urls {
     The type is derived from `string_view`,
     which provides compatibility with strings
     in terms of comparisons and conversions.
-
-    However, care must be exercised; undefined
-    behavior results if the string_view
-    portion of the object is modified
-    directly, for example by calling
-    `remove_suffix` or `operator=`.
-
-    Slicing, however, is supported, as
-    copies of the `string_view` portion
-    of the object are valid and remain
-    valid for the lifetime of the original
-    object.
 */
-class const_string : public string_view
+class const_string
 {
     static constexpr
     std::size_t
     builtin_capacity = 32;
+
+    const char* str_{nullptr};
+    std::size_t len_{0};
 
     struct base;
     struct result;
@@ -80,6 +75,20 @@ class const_string : public string_view
 
 public:
     class factory;
+
+    using value_type = char;
+    using pointer = char*;
+    using const_pointer = const char*;
+    using reference = char&;
+    using const_reference = const char&;
+    using const_iterator = const char*;
+    using iterator = const_iterator;
+    using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+    using reverse_iterator = const_reverse_iterator;
+    using size_type = std::size_t;
+    using difference_type = std::ptrdiff_t;
+
+    static constexpr size_type npos = size_type(-1);
 
     /** Destructor
 
@@ -164,6 +173,1458 @@ public:
     const_string(
         string_view s,
         Allocator const& a);
+
+   /** Constructor
+
+        Constructs a copy of the string `str`.
+        If memory allocation is required, the
+        specified allocator `a` will be used.
+
+        @param str The string to copy
+
+        @param a The allocator to use.
+    */
+    template<class Allocator>
+    const_string(
+        char const* str,
+        Allocator const& a)
+    : const_string(string_view(str), a)
+    {
+    }
+
+    /** Constructor
+
+        Constructs a copy of the string `str`.
+        If memory allocation is required, the
+        specified allocator `a` will be used.
+
+        @param str The string to copy
+
+        @param a The allocator to use.
+    */
+    template<class Allocator>
+    const_string(
+        char const* str,
+        size_type len,
+        Allocator const& a)
+    : const_string(string_view(str, len), a)
+    {
+    }
+
+#if !defined(BOOST_URL_NO_CXX17_HDR_STRING_VIEW)
+    /** Constructor
+
+        Constructs a copy of the string `s`.
+        If memory allocation is required, the
+        specified allocator `a` will be used.
+
+        @param s The string to copy
+
+        @param a The allocator to use.
+    */
+    template<class Allocator>
+    const_string(
+        std::string_view s,
+        Allocator const& a)
+    : const_string(string_view(s.data(), s.size()), a)
+    {
+    }
+#endif
+
+    /** Constructor
+
+        Constructs a copy of the string `s`.
+        If memory allocation is required, the
+        specified allocator `a` will be used.
+
+        @param s The string to copy
+
+        @param a The allocator to use.
+    */
+    template<class Alloc1, class Alloc2>
+    const_string(
+        const std::basic_string<
+            char, std::char_traits<char>, Alloc1
+        >& s,
+        Alloc2 const& a)
+    : const_string(string_view(s.data(), s.size()), a)
+    {
+    }
+
+    /** Returns an iterator to the beginning
+
+        Returns an iterator to the first character of the string
+
+        @return const_iterator to the first character
+    */
+    BOOST_URL_CONST_STRING_CONSTEXPR
+    const_iterator
+    begin() const noexcept
+    {
+        return str_;
+    }
+
+    /** Returns an iterator to the beginning
+
+        Returns an iterator to the first character of the string
+
+        @return const_iterator to the first character
+    */
+    BOOST_URL_CONST_STRING_CONSTEXPR
+    const_iterator
+    cbegin() const noexcept
+    {
+        return str_;
+    }
+
+    /** Returns an iterator to the end
+
+        Returns an iterator to one past the last character of the string.
+
+        This character acts as a placeholder, attempting to access it
+        results in undefined behavior.
+
+        @return const_iterator to the character following the last character
+    */
+    BOOST_URL_CONST_STRING_CONSTEXPR
+    const_iterator
+    end() const noexcept
+    {
+        return str_ + len_;
+    }
+
+    /** Returns an iterator to the end
+
+        Returns an iterator to one past the last character of the string.
+
+        This character acts as a placeholder, attempting to access it
+        results in undefined behavior.
+
+        @return const_iterator to the character following the last character
+    */
+    BOOST_URL_CONST_STRING_CONSTEXPR
+    const_iterator
+    cend() const noexcept
+    {
+        return str_ + len_;
+    }
+
+    /** Returns a reverse iterator to the beginning
+
+        Returns an iterator to the first char of the reversed string
+
+        It corresponds to the last character of the non-reversed string
+
+        @return const_reverse_iterator to the first character
+    */
+    inline
+    const_reverse_iterator
+    rbegin() const noexcept
+    {
+        return const_reverse_iterator(end());
+    }
+
+    /** Returns a reverse iterator to the beginning
+
+        Returns an iterator to the first char of the reversed string
+
+        It corresponds to the last character of the non-reversed string
+
+        @return const_reverse_iterator to the first character
+    */
+    inline
+    const_reverse_iterator
+    crbegin() const noexcept
+    {
+        return const_reverse_iterator(end());
+    }
+
+    /** Returns a reverse iterator to the end
+
+        Returns a reverse iterator to the character following the
+        last character of the reversed string.
+
+        It corresponds to the character preceding the first character
+        of the non-reversed string.
+
+        This character acts as a placeholder, attempting to access
+        it results in undefined behavior.
+
+        @return const_reverse_iterator to the character following
+        the last character
+    */
+    inline
+    const_reverse_iterator
+    rend() const noexcept
+    {
+        return const_reverse_iterator(begin());
+    }
+
+    /** Returns a reverse iterator to the end
+
+        Returns a reverse iterator to the character following the
+        last character of the reversed string.
+
+        It corresponds to the character preceding the first character
+        of the non-reversed string.
+
+        This character acts as a placeholder, attempting to access
+        it results in undefined behavior.
+
+        @return const_reverse_iterator to the character following
+        the last character
+    */
+    inline
+    const_reverse_iterator
+    crend() const noexcept
+    {
+        return const_reverse_iterator(begin());
+    }
+
+    /** Accesses the specified character
+
+        Returns a const reference to the character at specified
+        location pos.
+
+        No bounds checking is performed: the behavior is
+        undefined if `pos >= size()`
+
+        @note Unlike `std::basic_string::operator[]`, this function
+        has undefined behavior instead of returning char()
+
+        @param pos position of the character to return
+
+        @return Const reference to the requested character
+     */
+    BOOST_URL_CONST_STRING_CONSTEXPR
+    const_reference
+    operator[]( size_type pos ) const
+    {
+        return str_[pos];
+    }
+
+    /** Accesses the specified character with bounds checking
+
+        Returns a const reference to the character at specified
+        location pos.
+
+        Bounds checking is performed, exception of type
+        std::out_of_range will be thrown on invalid access.
+
+        @par Exception Safety
+        Strong guarantee.
+        Exceptions thrown on invalid positions.
+
+        @throw out_of_range Invalid position
+
+        @param pos position of the character to return
+
+        @return Const reference to the requested character
+     */
+    BOOST_URL_CONST_STRING_CONSTEXPR
+    const_reference
+    at( size_type pos ) const
+    {
+        if(pos >= size())
+            detail::throw_out_of_range(
+                BOOST_CURRENT_LOCATION);
+        return *(str_ + pos);
+    }
+
+    /** Accesses the first character
+
+        Returns reference to the first character in the string.
+
+        Equivalent to `operator[](0)`.
+
+        The behavior is undefined if `empty() == true`.
+
+        @return reference to the first character
+     */
+    BOOST_URL_CONST_STRING_CONSTEXPR
+    const_reference
+    front() const
+    {
+        BOOST_ASSERT( !empty() );
+        return *str_;
+    }
+
+    /** Accesses the last character
+
+        Returns reference to the last character in the string
+
+        Equivalent to `operator[](size() - 1)`.
+
+        The behavior is undefined if `empty() == true`.
+
+        @return reference to the first character
+     */
+    BOOST_URL_CONST_STRING_CONSTEXPR
+    const_reference
+    back() const
+    {
+        BOOST_ASSERT( !empty() );
+        return str_[len_ - 1];
+    }
+
+    /** Returns a pointer to the first character of a string
+
+        Returns a pointer to the underlying character array.
+
+        The pointer is such that the range `[data(); data() + size())`
+        is valid and the values in it correspond to the values of the
+        string.
+
+        @note Unlike `std::basic_string::data()` and string literals,
+        `data()` may return a pointer to a buffer that is not
+        null-terminated. Therefore, it is typically a mistake to pass
+        data() to a routine that takes just a const char* and expects
+        a null-terminated string.
+
+        @return A pointer to the underlying character array.
+     */
+    BOOST_URL_CONST_STRING_CONSTEXPR
+    const_pointer
+    data() const
+    {
+        return str_;
+    }
+
+    /** Returns the number of char elements in the string
+
+        @return The number of char elements in the string
+    */
+    BOOST_URL_CONST_STRING_CONSTEXPR
+    size_type
+    size() const noexcept
+    {
+        return len_;
+    }
+
+    /** Returns the number of char elements in the string
+
+        @return The number of char elements in the string
+    */
+    BOOST_URL_CONST_STRING_CONSTEXPR
+    size_type
+    length() const noexcept
+    {
+        return len_;
+    }
+
+    /** Returns the maximum number of characters
+
+        The largest possible number of char-like objects that
+        can be referred to by a const_string
+
+        @return Maximum number of characters
+    */
+    BOOST_URL_CONST_STRING_CONSTEXPR
+    size_type
+    max_size() const noexcept
+    {
+        return size_type( -1 );
+    }
+
+    /** Checks whether the string is empty
+
+        Checks if the string has no characters,
+        i.e. whether `size() == 0`.
+
+        @return `true` if the string is empty
+    */
+    BOOST_URL_CONST_STRING_CONSTEXPR
+    bool
+    empty() const noexcept
+    {
+        return len_ == 0;
+    }
+
+    /** Copies characters
+
+        Copies a substring to the character array pointed to by
+        the destination char string, where `rcount` is the smaller
+        of `count` and `size() - pos`.
+
+        Equivalent to
+        `std::char_traits<char>::copy(dest, data() + pos, rcount)`
+
+        @par Exception Safety
+        Strong guarantee.
+        Exceptions thrown on invalid positions.
+
+        @throw out_of_range If `pos > size()`
+
+        @param dest pointer to the destination character string
+        @param count requested substring length
+        @param pos position of the first character
+
+        @return Number of characters copied
+    */
+    BOOST_URL_CONST_STRING_CONSTEXPR
+    size_type
+    copy(char* dest,
+         size_type count,
+         size_type pos = 0) const
+    {
+        return operator string_view().copy(dest, count, pos);
+    }
+
+    /** Returns a substring
+
+        Returns a string view of a substring, where its size is the
+        smaller of `count` and `size() - pos`.
+
+        @par Exception Safety
+        Strong guarantee.
+        Exceptions thrown on invalid positions.
+
+        @throw out_of_range If `pos > size()`
+
+        @param dest pointer to the destination character string
+        @param count requested substring length
+        @param pos position of the first character
+
+        @return Number of characters copied
+    */
+    BOOST_URL_CONST_STRING_CONSTEXPR
+    string_view
+    substr(size_type pos = 0,
+           size_type count = npos) const
+    {
+        return operator string_view().substr(pos, count);
+    }
+
+    /** Compares two strings
+
+        The length of the sequences to compare is the smaller of
+        `size()` and `other.size()`.
+
+        The function compares the two strings by calling
+        `char_traits<char>::compare(data(), v.data(), rlen)`.
+
+        @param other string to compare
+
+        @return Negative value if this string is less than the other
+        character sequence, zero if the both character sequences are
+        equal, positive value if this string is greater than the other
+        character sequence
+    */
+    BOOST_URL_CONST_STRING_CONSTEXPR
+    int
+    compare(string_view other) const
+    {
+        return operator string_view().compare(other);
+    }
+
+    /** Compares two strings
+
+        Equivalent to `substr(pos1, count1).compare(other)`
+
+        @par Exception Safety
+        Strong guarantee.
+        Exceptions thrown on invalid positions.
+
+        @throw out_of_range If `pos1 > size()`
+
+        @param pos1 position of the first character in this string to compare
+        @param count1 number of characters of this string to compare
+        @param other string to compare
+
+        @return Negative value if this string is less than the other
+        character sequence, zero if the both character sequences are
+        equal, positive value if this string is greater than the other
+        character sequence
+    */
+    BOOST_URL_CONST_STRING_CONSTEXPR
+    int
+    compare(
+        size_type pos1,
+        size_type count1,
+        string_view other) const
+    {
+        return substr(pos1, count1).compare(other);
+    }
+
+    /** Compares two strings
+
+        Equivalent to
+        `substr(pos1, count1).compare(other.substr(pos2, count2))`
+
+        @par Exception Safety
+        Strong guarantee.
+        Exceptions thrown on invalid positions.
+
+        @throw out_of_range If `pos1 > size()` or `pos2 > other.size()`
+
+        @param pos1 position of the first character in this string to compare
+        @param count1 number of characters of this string to compare
+        @param other string to compare
+        @param pos2 position of the first character in the string to compare
+        @param count2 number of characters of the given string to compare
+
+        @return Negative value if this string is less than the other
+        character sequence, zero if the both character sequences are
+        equal, positive value if this string is greater than the other
+        character sequence
+    */
+    BOOST_URL_CONST_STRING_CONSTEXPR
+    int
+    compare(
+        size_type pos1,
+        size_type count1,
+        string_view other,
+        size_type pos2,
+        size_type count2) const
+    {
+        return substr(pos1, count1).compare(
+          other.substr(pos2, count2));
+    }
+
+    /** Compares two strings
+
+        Equivalent to `compare(string_view(s))`
+
+        @par Exception Safety
+        Strong guarantee.
+        Exceptions thrown on invalid positions.
+
+        @throw out_of_range If `pos1 > size()` or `pos2 > other.size()`
+
+        @param s pointer to the character string to compare to
+
+        @return Negative value if this string is less than the other
+        character sequence, zero if the both character sequences are
+        equal, positive value if this string is greater than the other
+        character sequence
+    */
+    BOOST_URL_CONST_STRING_CONSTEXPR
+    int
+    compare(const char* s) const
+    {
+        return compare(string_view(s));
+    }
+
+    /** Compares two strings
+
+        Equivalent to `substr(pos1, count1).compare(string_view(s))`
+
+        @par Exception Safety
+        Strong guarantee.
+        Exceptions thrown on invalid positions.
+
+        @throw out_of_range If `pos1 > size()`
+
+        @param pos1 position of the first character in this string to compare
+        @param count1 number of characters of this string to compare
+        @param s pointer to the character string to compare to
+
+        @return Negative value if this string is less than the other
+        character sequence, zero if the both character sequences are
+        equal, positive value if this string is greater than the other
+        character sequence
+    */
+    BOOST_URL_CONST_STRING_CONSTEXPR
+    int
+    compare(
+        size_type pos1,
+        size_type count1,
+        const char* s) const
+    {
+        return substr(pos1, count1).compare(
+          string_view(s));
+    }
+
+    /** Compares two strings
+
+        Equivalent to
+        `substr(pos1, count1).compare(string_view(s, count2))`
+
+        @par Exception Safety
+        Strong guarantee.
+        Exceptions thrown on invalid positions.
+
+        @throw out_of_range If `pos1 > size()` or `pos2 > other.size()`
+
+        @param pos1 position of the first character in this string to compare
+        @param count1 number of characters of this string to compare
+        @param s pointer to the character string to compare to
+        @param count2 number of characters of the given string to compare
+
+        @return Negative value if this string is less than the other
+        character sequence, zero if the both character sequences are
+        equal, positive value if this string is greater than the other
+        character sequence
+    */
+    BOOST_URL_CONST_STRING_CONSTEXPR
+    int
+    compare(
+        size_type pos1,
+        size_type count1,
+        const char* s,
+        size_type count2) const
+    {
+        return substr(pos1, count1).compare(
+          string_view(s, count2));
+    }
+
+    /** Returns a urls::string_view
+
+        @note It is the programmer's responsibility
+        to ensure that the resulting string view
+        does not outlive the string.
+
+        @return A string_view representing the
+        entire contents of the string.
+    */
+    BOOST_URL_CONST_STRING_CONSTEXPR
+    operator string_view() const noexcept
+    {
+        return string_view(str_, len_);
+    }
+
+#ifndef BOOST_URL_NO_CXX17_HDR_STRING_VIEW
+    /** Returns a std::string_view
+
+        @note It is the programmer's responsibility
+        to ensure that the resulting string view
+        does not outlive the string.
+
+        @return A string_view representing the
+        entire contents of the string.
+    */
+    BOOST_URL_CONST_STRING_CONSTEXPR
+    operator std::string_view() const noexcept
+    {
+        return std::string_view(str_, len_);
+    }
+#endif
+
+    /** Returns a basic_string
+
+        @return A string representing the
+        entire contents of the const_string.
+    */
+    template <class A>
+    BOOST_URL_CONST_STRING_CONSTEXPR
+    operator std::basic_string<char, std::char_traits<char>, A>() const
+    {
+        return std::basic_string<
+            char, std::char_traits<char>, A>(str_, len_);
+    }
+
+    /** Compares two strings
+
+        @param lhs A const_string to compare
+        @param rhs A const_string to compare
+
+        @return true if the corresponding comparison holds
+      */
+    friend BOOST_URL_CONST_STRING_CONSTEXPR
+    bool
+    operator==( const_string const& lhs,
+                const_string const& rhs ) noexcept
+    {
+        return lhs.compare(rhs) == 0;
+    }
+
+    /** Compares two strings
+
+        @param lhs A const_string to compare
+        @param rhs A const_string to compare
+
+        @return true if the corresponding comparison holds
+      */
+    friend BOOST_URL_CONST_STRING_CONSTEXPR
+    bool
+    operator!=( const_string const& lhs,
+                const_string const& rhs ) noexcept
+    {
+        return lhs.compare(rhs) != 0;
+    }
+
+    /** Compares two strings
+
+        @param lhs A const_string to compare
+        @param rhs A const_string to compare
+
+        @return true if the corresponding comparison holds
+     */
+    friend BOOST_URL_CONST_STRING_CONSTEXPR
+    bool
+    operator<( const_string const& lhs,
+               const_string const& rhs ) noexcept
+    {
+        return lhs.compare(rhs) < 0;
+    }
+
+    /** Compares two strings
+
+        @param lhs A const_string to compare
+        @param rhs A const_string to compare
+
+        @return true if the corresponding comparison holds
+     */
+    friend BOOST_URL_CONST_STRING_CONSTEXPR
+    bool
+    operator<=( const_string const& lhs,
+                const_string const& rhs ) noexcept
+    {
+        return lhs.compare(rhs) <= 0;
+    }
+
+    /** Compares two strings
+
+        @param lhs A const_string to compare
+        @param rhs A const_string to compare
+
+        @return true if the corresponding comparison holds
+     */
+    friend BOOST_URL_CONST_STRING_CONSTEXPR
+    bool
+    operator>( const_string const& lhs,
+               const_string const& rhs ) noexcept
+    {
+        return lhs.compare(rhs) > 0;
+    }
+
+    /** Compares two strings
+
+        @param lhs A const_string to compare
+        @param rhs A const_string to compare
+
+        @return true if the corresponding comparison holds
+     */
+    friend BOOST_URL_CONST_STRING_CONSTEXPR
+    bool
+    operator>=( const_string const& lhs,
+                const_string const& rhs ) noexcept
+    {
+        return lhs.compare(rhs) >= 0;
+    }
+
+    /** Compares two strings
+
+        @param lhs A const_string to compare
+        @param rhs A string_view to compare
+
+        @return true if the corresponding comparison holds
+      */
+    friend BOOST_URL_CONST_STRING_CONSTEXPR
+    bool
+    operator==( const_string const& lhs,
+                string_view rhs ) noexcept
+    {
+        return lhs.compare(rhs) == 0;
+    }
+
+    /** Compares two strings
+
+        @param lhs A const_string to compare
+        @param rhs A string_view to compare
+
+        @return true if the corresponding comparison holds
+      */
+    friend BOOST_URL_CONST_STRING_CONSTEXPR
+    bool
+    operator!=( const_string const& lhs,
+                string_view rhs ) noexcept
+    {
+        return lhs.compare(rhs) != 0;
+    }
+
+    /** Compares two strings
+
+        @param lhs A const_string to compare
+        @param rhs A string_view to compare
+
+        @return true if the corresponding comparison holds
+     */
+    friend BOOST_URL_CONST_STRING_CONSTEXPR
+    bool
+    operator<( const_string const& lhs,
+               string_view rhs ) noexcept
+    {
+        return lhs.compare(rhs) < 0;
+    }
+
+    /** Compares two strings
+
+        @param lhs A const_string to compare
+        @param rhs A string_view to compare
+
+        @return true if the corresponding comparison holds
+     */
+    friend BOOST_URL_CONST_STRING_CONSTEXPR
+    bool
+    operator<=( const_string const& lhs,
+                string_view rhs ) noexcept
+    {
+        return lhs.compare(rhs) <= 0;
+    }
+
+    /** Compares two strings
+
+        @param lhs A const_string to compare
+        @param rhs A string_view to compare
+
+        @return true if the corresponding comparison holds
+     */
+    friend BOOST_URL_CONST_STRING_CONSTEXPR
+    bool
+    operator>( const_string const& lhs,
+               string_view rhs ) noexcept
+    {
+        return lhs.compare(rhs) > 0;
+    }
+
+    /** Compares two strings
+
+        @param lhs A const_string to compare
+        @param rhs A string_view to compare
+
+        @return true if the corresponding comparison holds
+     */
+    friend BOOST_URL_CONST_STRING_CONSTEXPR
+    bool
+    operator>=( const_string const& lhs,
+                string_view rhs ) noexcept
+    {
+        return lhs.compare(rhs) >= 0;
+    }
+
+    /** Compares two strings
+
+        @param lhs A const_string to compare
+        @param rhs A string_view to compare
+
+        @return true if the corresponding comparison holds
+      */
+    friend BOOST_URL_CONST_STRING_CONSTEXPR
+    bool
+    operator==( string_view lhs,
+                const_string const& rhs ) noexcept
+    {
+        return rhs.compare(lhs) == 0;
+    }
+
+    /** Compares two strings
+
+        @param lhs A const_string to compare
+        @param rhs A string_view to compare
+
+        @return true if the corresponding comparison holds
+      */
+    friend BOOST_URL_CONST_STRING_CONSTEXPR
+    bool
+    operator!=( string_view lhs,
+                const_string const& rhs ) noexcept
+    {
+        return rhs.compare(lhs) != 0;
+    }
+
+    /** Compares two strings
+
+        @param lhs A const_string to compare
+        @param rhs A string_view to compare
+
+        @return true if the corresponding comparison holds
+     */
+    friend BOOST_URL_CONST_STRING_CONSTEXPR
+    bool
+    operator<( string_view lhs,
+               const_string const& rhs ) noexcept
+    {
+        return rhs.compare(lhs) > 0;
+    }
+
+    /** Compares two strings
+
+        @param lhs A const_string to compare
+        @param rhs A string_view to compare
+
+        @return true if the corresponding comparison holds
+     */
+    friend BOOST_URL_CONST_STRING_CONSTEXPR
+    bool
+    operator<=( string_view lhs,
+                const_string const& rhs ) noexcept
+    {
+        return rhs.compare(lhs) >= 0;
+    }
+
+    /** Compares two strings
+
+        @param lhs A const_string to compare
+        @param rhs A string_view to compare
+
+        @return true if the corresponding comparison holds
+     */
+    friend BOOST_URL_CONST_STRING_CONSTEXPR
+    bool
+    operator>( string_view lhs,
+               const_string const& rhs ) noexcept
+    {
+        return rhs.compare(lhs) < 0;
+    }
+
+    /** Compares two strings
+
+        @param lhs A const_string to compare
+        @param rhs A string_view to compare
+
+        @return true if the corresponding comparison holds
+     */
+    friend BOOST_URL_CONST_STRING_CONSTEXPR
+    bool
+    operator>=( string_view lhs,
+                const_string const& rhs ) noexcept
+    {
+        return rhs.compare(lhs) <= 0;
+    }
+
+#if !defined(BOOST_URL_NO_CXX17_HDR_STRING_VIEW)
+    // "sufficient number of additional overloads"
+    // against std::string_view as in urls::string_view
+
+    /** Compares two strings
+
+        @param lhs A const_string to compare
+        @param rhs A std::string_view to compare
+
+        @return true if the corresponding comparison holds
+      */
+    friend
+    bool
+    operator==( const_string const& lhs,
+                std::string_view rhs ) noexcept
+    {
+        return lhs.compare(rhs) == 0;
+    }
+
+    /** Compares two strings
+
+        @param lhs A const_string to compare
+        @param rhs A std::string_view to compare
+
+        @return true if the corresponding comparison holds
+      */
+    friend
+    bool
+    operator!=( const_string const& lhs,
+                std::string_view rhs ) noexcept
+    {
+        return lhs.compare(rhs) != 0;
+    }
+
+    /** Compares two strings
+
+        @param lhs A const_string to compare
+        @param rhs A std::string_view to compare
+
+        @return true if the corresponding comparison holds
+     */
+    friend
+    bool
+    operator<( const_string const& lhs,
+               std::string_view rhs ) noexcept
+    {
+        return lhs.compare(rhs) < 0;
+    }
+
+    /** Compares two strings
+
+        @param lhs A const_string to compare
+        @param rhs A std::string_view to compare
+
+        @return true if the corresponding comparison holds
+     */
+    friend
+    bool
+    operator<=( const_string const& lhs,
+                std::string_view rhs ) noexcept
+    {
+        return lhs.compare(rhs) <= 0;
+    }
+
+    /** Compares two strings
+
+        @param lhs A const_string to compare
+        @param rhs A std::string_view to compare
+
+        @return true if the corresponding comparison holds
+     */
+    friend
+    bool
+    operator>( const_string const& lhs,
+               std::string_view rhs ) noexcept
+    {
+        return lhs.compare(rhs) > 0;
+    }
+
+    /** Compares two strings
+
+        @param lhs A const_string to compare
+        @param rhs A std::string_view to compare
+
+        @return true if the corresponding comparison holds
+     */
+    friend
+    bool
+    operator>=( const_string const& lhs,
+                std::string_view rhs ) noexcept
+    {
+        return lhs.compare(rhs) >= 0;
+    }
+
+    /** Compares two strings
+
+        @param lhs A const_string to compare
+        @param rhs A std::string_view to compare
+
+        @return true if the corresponding comparison holds
+      */
+    friend
+    bool
+    operator==( std::string_view lhs,
+                const_string const& rhs ) noexcept
+    {
+        return rhs.compare(lhs) == 0;
+    }
+
+    /** Compares two strings
+
+        @param lhs A const_string to compare
+        @param rhs A std::string_view to compare
+
+        @return true if the corresponding comparison holds
+      */
+    friend
+    bool
+    operator!=( std::string_view lhs,
+                const_string const& rhs ) noexcept
+    {
+        return rhs.compare(lhs) != 0;
+    }
+
+    /** Compares two strings
+
+        @param lhs A const_string to compare
+        @param rhs A std::string_view to compare
+
+        @return true if the corresponding comparison holds
+     */
+    friend
+    bool
+    operator<( std::string_view lhs,
+               const_string const& rhs ) noexcept
+    {
+        return rhs.compare(lhs) > 0;
+    }
+
+    /** Compares two strings
+
+        @param lhs A const_string to compare
+        @param rhs A std::string_view to compare
+
+        @return true if the corresponding comparison holds
+     */
+    friend
+    bool
+    operator<=( std::string_view lhs,
+                const_string const& rhs ) noexcept
+    {
+        return rhs.compare(lhs) >= 0;
+    }
+
+    /** Compares two strings
+
+        @param lhs A const_string to compare
+        @param rhs A std::string_view to compare
+
+        @return true if the corresponding comparison holds
+     */
+    friend
+    bool
+    operator>( std::string_view lhs,
+               const_string const& rhs ) noexcept
+    {
+        return rhs.compare(lhs) < 0;
+    }
+
+    /** Compares two strings
+
+        @param lhs A const_string to compare
+        @param rhs A std::string_view to compare
+
+        @return true if the corresponding comparison holds
+     */
+    friend
+    bool
+    operator>=( std::string_view lhs,
+                const_string const& rhs ) noexcept
+    {
+        return rhs.compare(lhs) <= 0;
+    }
+#endif
+
+    // "sufficient number of additional overloads" against types
+    // convertible to both urls::string_view and std::string_view
+
+    /** Compares two strings
+
+        @note This function only participates in overload resolution
+        if we can construct a string_view from the types being
+        compared.
+
+        @tparam StringViewable A type from which we can construct a string_view
+
+        @param lhs A const_string to compare
+        @param rhs A StringViewable to compare
+
+        @return true if the corresponding comparison holds
+      */
+    template <class StringViewable>
+    friend
+    BOOST_URL_CONST_STRING_CONSTEXPR
+#ifndef BOOST_URL_DOCS
+    typename std::enable_if<
+        std::is_constructible<string_view, StringViewable>::value, bool
+    >::type
+#else
+    bool
+#endif
+    operator==( const_string const& lhs,
+                StringViewable const& rhs ) noexcept
+    {
+        return lhs.compare(string_view(rhs)) == 0;
+    }
+
+    /** Compares two strings
+
+        @note This function only participates in overload resolution
+        if we can construct a string_view from the types being
+        compared.
+
+        @tparam StringViewable A type from which we can construct a string_view
+
+        @param lhs A const_string to compare
+        @param rhs A StringViewable to compare
+
+        @return true if the corresponding comparison holds
+      */
+    template <class StringViewable>
+    friend
+    BOOST_URL_CONST_STRING_CONSTEXPR
+#ifndef BOOST_URL_DOCS
+    typename std::enable_if<
+        std::is_constructible<string_view, StringViewable>::value, bool
+    >::type
+#else
+    bool
+#endif
+    operator!=( const_string const& lhs,
+                StringViewable const& rhs ) noexcept
+    {
+        return lhs.compare(string_view(rhs)) != 0;
+    }
+
+    /** Compares two strings
+
+        @note This function only participates in overload resolution
+        if we can construct a string_view from the types being
+        compared.
+
+        @tparam StringViewable A type from which we can construct a string_view
+
+        @param lhs A const_string to compare
+        @param rhs A StringViewable to compare
+
+        @return true if the corresponding comparison holds
+     */
+    template <class StringViewable>
+    friend
+    BOOST_URL_CONST_STRING_CONSTEXPR
+#ifndef BOOST_URL_DOCS
+    typename std::enable_if<
+        std::is_constructible<string_view, StringViewable>::value, bool
+    >::type
+#else
+    bool
+#endif
+    operator<( const_string const& lhs,
+               StringViewable const& rhs ) noexcept
+    {
+        return lhs.compare(string_view(rhs)) < 0;
+    }
+
+    /** Compares two strings
+
+        @note This function only participates in overload resolution
+        if we can construct a string_view from the types being
+        compared.
+
+        @tparam StringViewable A type from which we can construct a string_view
+
+        @param lhs A const_string to compare
+        @param rhs A StringViewable to compare
+
+        @return true if the corresponding comparison holds
+     */
+    template <class StringViewable>
+    friend
+    BOOST_URL_CONST_STRING_CONSTEXPR
+#ifndef BOOST_URL_DOCS
+    typename std::enable_if<
+        std::is_constructible<string_view, StringViewable>::value, bool
+    >::type
+#else
+    bool
+#endif
+    operator<=( const_string const& lhs,
+                StringViewable const& rhs ) noexcept
+    {
+        return lhs.compare(string_view(rhs)) <= 0;
+    }
+
+    /** Compares two strings
+
+        @note This function only participates in overload resolution
+        if we can construct a string_view from the types being
+        compared.
+
+        @tparam StringViewable A type from which we can construct a string_view
+
+        @param lhs A const_string to compare
+        @param rhs A StringViewable to compare
+
+        @return true if the corresponding comparison holds
+     */
+    template <class StringViewable>
+    friend
+    BOOST_URL_CONST_STRING_CONSTEXPR
+#ifndef BOOST_URL_DOCS
+    typename std::enable_if<
+        std::is_constructible<string_view, StringViewable>::value, bool
+    >::type
+#else
+    bool
+#endif
+    operator>( const_string const& lhs,
+               StringViewable const& rhs ) noexcept
+    {
+        return lhs.compare(string_view(rhs)) > 0;
+    }
+
+    /** Compares two strings
+
+        @note This function only participates in overload resolution
+        if we can construct a string_view from the types being
+        compared.
+
+        @tparam StringViewable A type from which we can construct a string_view
+
+        @param lhs A const_string to compare
+        @param rhs A StringViewable to compare
+
+        @return true if the corresponding comparison holds
+     */
+    template <class StringViewable>
+    friend
+    BOOST_URL_CONST_STRING_CONSTEXPR
+#ifndef BOOST_URL_DOCS
+    typename std::enable_if<
+        std::is_constructible<string_view, StringViewable>::value, bool
+    >::type
+#else
+    bool
+#endif
+    operator>=( const_string const& lhs,
+                StringViewable const& rhs ) noexcept
+    {
+        return lhs.compare(string_view(rhs)) >= 0;
+    }
+
+    /** Compares two strings
+
+        @note This function only participates in overload resolution
+        if we can construct a string_view from the types being
+        compared.
+
+        @tparam StringViewable A type from which we can construct a string_view
+
+        @param lhs A const_string to compare
+        @param rhs A StringViewable to compare
+
+        @return true if the corresponding comparison holds
+      */
+    template <class StringViewable>
+    friend
+    BOOST_URL_CONST_STRING_CONSTEXPR
+#ifndef BOOST_URL_DOCS
+    typename std::enable_if<
+        std::is_constructible<string_view, StringViewable>::value, bool
+    >::type
+#else
+    bool
+#endif
+    operator==( StringViewable const& lhs,
+                const_string const& rhs ) noexcept
+    {
+        return rhs.compare(lhs) == 0;
+    }
+
+    /** Compares two strings
+
+        @note This function only participates in overload resolution
+        if we can construct a string_view from the types being
+        compared.
+
+        @tparam StringViewable A type from which we can construct a string_view
+
+        @param lhs A const_string to compare
+        @param rhs A StringViewable to compare
+
+        @return true if the corresponding comparison holds
+      */
+    template <class StringViewable>
+    friend
+    BOOST_URL_CONST_STRING_CONSTEXPR
+#ifndef BOOST_URL_DOCS
+    typename std::enable_if<
+        std::is_constructible<string_view, StringViewable>::value, bool
+    >::type
+#else
+    bool
+#endif
+    operator!=( StringViewable const& lhs,
+                const_string const& rhs ) noexcept
+    {
+        return rhs.compare(lhs) != 0;
+    }
+
+    /** Compares two strings
+
+        @note This function only participates in overload resolution
+        if we can construct a string_view from the types being
+        compared.
+
+        @tparam StringViewable A type from which we can construct a string_view
+
+        @param lhs A const_string to compare
+        @param rhs A StringViewable to compare
+
+        @return true if the corresponding comparison holds
+     */
+    template <class StringViewable>
+    friend
+    BOOST_URL_CONST_STRING_CONSTEXPR
+#ifndef BOOST_URL_DOCS
+    typename std::enable_if<
+        std::is_constructible<string_view, StringViewable>::value, bool
+    >::type
+#else
+    bool
+#endif
+    operator<( StringViewable const& lhs,
+               const_string const& rhs ) noexcept
+    {
+        return rhs.compare(lhs) > 0;
+    }
+
+    /** Compares two strings
+
+        @note This function only participates in overload resolution
+        if we can construct a string_view from the types being
+        compared.
+
+        @tparam StringViewable A type from which we can construct a string_view
+
+        @param lhs A const_string to compare
+        @param rhs A StringViewable to compare
+
+        @return true if the corresponding comparison holds
+     */
+    template <class StringViewable>
+    friend
+    BOOST_URL_CONST_STRING_CONSTEXPR
+#ifndef BOOST_URL_DOCS
+    typename std::enable_if<
+        std::is_constructible<string_view, StringViewable>::value, bool
+    >::type
+#else
+    bool
+#endif
+    operator<=( StringViewable const& lhs,
+                const_string const& rhs ) noexcept
+    {
+        return rhs.compare(lhs) >= 0;
+    }
+
+    /** Compares two strings
+
+        @note This function only participates in overload resolution
+        if we can construct a string_view from the types being
+        compared.
+
+        @tparam StringViewable A type from which we can construct a string_view
+
+        @param lhs A const_string to compare
+        @param rhs A StringViewable to compare
+
+        @return true if the corresponding comparison holds
+     */
+    template <class StringViewable>
+    friend
+    BOOST_URL_CONST_STRING_CONSTEXPR
+#ifndef BOOST_URL_DOCS
+    typename std::enable_if<
+        std::is_constructible<string_view, StringViewable>::value, bool
+    >::type
+#else
+    bool
+#endif
+    operator>( StringViewable const& lhs,
+               const_string const& rhs ) noexcept
+    {
+        return rhs.compare(lhs) < 0;
+    }
+
+    /** Compares two strings
+
+        @note This function only participates in overload resolution
+        if we can construct a string_view from the types being
+        compared.
+
+        @tparam StringViewable A type from which we can construct a string_view
+
+        @param lhs A const_string to compare
+        @param rhs A StringViewable to compare
+
+        @return true if the corresponding comparison holds
+     */
+    template <class StringViewable>
+    friend
+    BOOST_URL_CONST_STRING_CONSTEXPR
+#ifndef BOOST_URL_DOCS
+    typename std::enable_if<
+        std::is_constructible<string_view, StringViewable>::value, bool
+    >::type
+#else
+    bool
+#endif
+    operator>=( StringViewable const& lhs,
+                const_string const& rhs ) noexcept
+    {
+        return rhs.compare(lhs) <= 0;
+    }
+
+    friend inline
+    std::ostream&
+    operator<<(std::ostream& os,
+               const_string const& cs) {
+      return os << cs.operator string_view();
+    }
 };
 
 //------------------------------------------------

--- a/include/boost/url/detail/config.hpp
+++ b/include/boost/url/detail/config.hpp
@@ -75,4 +75,26 @@
          return &loc; }()))
 #endif
 
+// This is a workaround for C++1z GCC
+// implementations which falsely claim
+// `const_string` comparisons cannot be
+// constexpr.
+#if BOOST_WORKAROUND( BOOST_GCC_VERSION, >= 50000 ) && \
+    BOOST_WORKAROUND( BOOST_GCC_VERSION, < 70000 )
+# define BOOST_URL_CONST_STRING_CONSTEXPR
+#else
+# define BOOST_URL_CONST_STRING_CONSTEXPR BOOST_CXX14_CONSTEXPR
+#endif
+
+// This is a workaround to also avoid implicit conversions to
+// std::string_view in Clang/GCC5 + C++1z as it falsely considers
+// the copy/move constructors of core::string_view ambiguous
+#if defined(BOOST_NO_CXX17_HDR_STRING_VIEW) || \
+    BOOST_WORKAROUND( BOOST_GCC_VERSION, < 60000 ) || \
+    BOOST_WORKAROUND( BOOST_CLANG_VERSION, < 60000 ) || \
+    (defined(__MINGW32__) && BOOST_WORKAROUND( BOOST_GCC_VERSION, < 90000 ))
+#define BOOST_URL_NO_CXX17_HDR_STRING_VIEW
+#endif
+
+
 #endif

--- a/include/boost/url/impl/const_string.hpp
+++ b/include/boost/url/impl/const_string.hpp
@@ -177,14 +177,14 @@ const_string(
     {
         std::memcpy(data_.buf_,
             s.data(), s.size());
-        static_cast<string_view&>(*this
-            ) = { data_.buf_, s.size()};
+        str_ = data_.buf_;
+        len_ = s.size();
         return;
     }
     auto r = factory::impl<Allocator>(
         a).construct(s.size());
-    static_cast<string_view&>(
-        *this) = { r.data, r.size };
+    str_ = r.data;
+    len_ = r.size;
     std::memcpy(r.data, s.data(), s.size());
     data_.p_ = r.p;
 }
@@ -201,14 +201,14 @@ const_string(
     if (is_small(size))
     {
         init(size, data_.buf_);
-        static_cast<string_view&>(
-            *this) = { data_.buf_, size };
+        str_ = data_.buf_;
+        len_ = size;
         return;
     }
     auto r = factory::impl<
         Allocator>(a).construct(size);
-    static_cast<string_view&>(
-        *this) = { r.data, r.size };
+    str_ = r.data;
+    len_ = r.size;
     init(size, r.data);
     data_.p_ = r.p;
 }

--- a/include/boost/url/impl/const_string.ipp
+++ b/include/boost/url/impl/const_string.ipp
@@ -127,7 +127,8 @@ operator()(string_view s) const
 const_string::
 const_string(
     result const& r) noexcept
-    : string_view(r.data, r.size)
+    : str_(r.data)
+    , len_(r.size)
     , data_(r.p)
 {
 }
@@ -141,14 +142,14 @@ const_string::
 
 const_string::
 const_string() noexcept
-    : string_view()
+    : str_(nullptr), len_(0)
 {
 }
 
 const_string::
 const_string(
     const_string const& other) noexcept
-    : string_view()
+    : str_(nullptr), len_(0)
 {
     if (is_small(other.size()))
     {
@@ -156,14 +157,14 @@ const_string(
         // nothing to release
         std::memcpy( data_.buf_,
             other.data_.buf_, other.size());
-        static_cast<string_view&>(*this) =
-            string_view(data_.buf_, other.size());
+        str_ = data_.buf_;
+        len_ = other.size();
         return;
     }
     data_.p_ = other.data_.p_;
     ++data_.p_->refs;
-    static_cast<string_view&>(
-        *this) = string_view(other);
+    str_ = other.str_;
+    len_ = other.len_;
 }
 
 const_string&
@@ -179,16 +180,16 @@ operator=(
             return *this;
         std::memcpy(data_.buf_,
             other.data_.buf_, other.size());
-        static_cast<string_view&>(*this) =
-            string_view(data_.buf_, other.size());
+        str_ = data_.buf_;
+        len_ = other.size();
         return *this;
     }
     ++other.data_.p_->refs;
     if (!is_small(size()))
         data_.p_->release(size());
     data_.p_ = other.data_.p_;
-    static_cast<string_view&>(
-        *this) = string_view(other);
+    str_ = other.str_;
+    len_ = other.len_;
     return *this;
 }
 

--- a/test/unit/const_string.cpp
+++ b/test/unit/const_string.cpp
@@ -316,11 +316,209 @@ struct const_string_test
         }
     }
 
+    template <class SV>
+    void
+    testSvFunctions()
+    {
+        std::allocator<char> a;
+        const_string s("test string", a);
+
+        // iterators
+        BOOST_TEST(*s.begin() == 't');
+        BOOST_TEST(*s.cbegin() == 't');
+        BOOST_TEST(*std::prev(s.end()) == 'g');
+        BOOST_TEST(*std::prev(s.cend()) == 'g');
+        BOOST_TEST(*s.rbegin() == 'g');
+        BOOST_TEST(*s.crbegin() == 'g');
+        BOOST_TEST(*std::prev(s.rend()) == 't');
+        BOOST_TEST(*std::prev(s.crend()) == 't');
+
+        // element access
+        BOOST_TEST(s[0] == 't');
+        BOOST_TEST(s.at(0) == 't');
+        BOOST_TEST(s.front() == 't');
+        BOOST_TEST(s.back() == 'g');
+        BOOST_TEST(*s.data() == 't');
+
+        // capacity
+        BOOST_TEST(s.size() == 11);
+        BOOST_TEST(s.length() == 11);
+        BOOST_TEST(s.max_size() == std::size_t(-1));
+        BOOST_TEST(!s.empty());
+
+        // operations
+        char dest[20];
+        s.copy(dest, 7);
+        BOOST_TEST(string_view(dest, 5) == "test ");
+        s.copy(dest, 7, 1);
+        BOOST_TEST(string_view(dest, 5) == "est s");
+        BOOST_TEST(s.substr() == "test string");
+        BOOST_TEST(s.substr(2) == "st string");
+        BOOST_TEST(s.substr(2, 2) == "st");
+        BOOST_TEST(s.compare(string_view("test string")) == 0);
+        BOOST_TEST(s.compare(string_view("a")) > 0);
+        BOOST_TEST(s.compare(string_view("a")) > 0);
+        BOOST_TEST(s.compare(string_view("z")) < 0);
+        BOOST_TEST(s.compare(0, 4, string_view("test")) == 0);
+        BOOST_TEST(s.compare(0, 4, string_view("a")) > 0);
+        BOOST_TEST(s.compare(0, 4, string_view("z")) < 0);
+        BOOST_TEST(s.compare(0, 4, string_view("test other"), 0, 4) == 0);
+        BOOST_TEST(s.compare(0, 4, string_view("a other"), 0, 1) > 0);
+        BOOST_TEST(s.compare(0, 4, string_view("z other"), 0, 1) < 0);
+        BOOST_TEST(s.compare(0, 4, string_view("z other"), 0, 1) < 0);
+        BOOST_TEST(s.compare(0, 4, string_view("the test other"), 4, 4) == 0);
+        BOOST_TEST(s.compare(0, 4, string_view("the a other"), 4, 1) > 0);
+        BOOST_TEST(s.compare(0, 4, string_view("the z other"), 4, 1) < 0);
+        BOOST_TEST(s.compare(0, 4, string_view("the z other"), 4, 1) < 0);
+        BOOST_TEST(s.compare("test string") == 0);
+        BOOST_TEST(s.compare("a") > 0);
+        BOOST_TEST(s.compare("z") < 0);
+        BOOST_TEST(s.compare(0, 4, "test") == 0);
+        BOOST_TEST(s.compare(0, 4, "a") > 0);
+        BOOST_TEST(s.compare(0, 4, "z") < 0);
+        BOOST_TEST(s.compare(0, 4, "test other", 4) == 0);
+        BOOST_TEST(s.compare(0, 4, "a other", 1) > 0);
+        BOOST_TEST(s.compare(0, 4, "z other", 1) < 0);
+        BOOST_TEST(s.compare(0, 4, "z other", 1) < 0);
+
+        // conversions
+        // const_string -> string_view
+        auto sv_fn = [](SV sv) {
+            return sv.size();
+        };
+        BOOST_TEST(sv_fn(s) == 11);
+
+        // const_string -> std::string
+        auto str_fn = [](std::string const& str) {
+            return str.size();
+        };
+        BOOST_TEST(str_fn(s) == 11);
+
+        // string <- const_string
+        {
+            std::string str(s);
+            (void) str;
+        }
+        {
+            std::string str = s;
+            (void) str;
+        }
+
+        // string_view <- const_string
+        {
+            SV sv(s);
+            (void) sv;
+        }
+        {
+            SV sv = s;
+            (void) sv;
+        }
+
+        // A(string_view) <- const_string
+        struct A
+        {
+            A(SV) {}
+        };
+        {
+            A aa(s);
+            (void) aa;
+        }
+
+        // A(std::string const&) <- const_string
+        struct B
+        {
+            B(std::string const&) {}
+        };
+        {
+            B bb(s);
+            (void) s;
+        }
+
+        // const_string <=> const_string
+        {
+            const_string eq_s("test string", a);
+            const_string l_s("a", a);
+            const_string g_s("z", a);
+            BOOST_TEST(s == eq_s);
+            BOOST_TEST(!(s == l_s));
+            BOOST_TEST(!(s == g_s));
+            BOOST_TEST(!(s != eq_s));
+            BOOST_TEST(s != l_s);
+            BOOST_TEST(s != g_s);
+            BOOST_TEST(!(s < eq_s));
+            BOOST_TEST(s < g_s);
+            BOOST_TEST(!(s < l_s));
+            BOOST_TEST(s <= eq_s);
+            BOOST_TEST(s <= g_s);
+            BOOST_TEST(!(s <= l_s));
+            BOOST_TEST(!(s > eq_s));
+            BOOST_TEST(!(s > g_s));
+            BOOST_TEST(s > l_s);
+            BOOST_TEST(s >= eq_s);
+            BOOST_TEST(!(s >= g_s));
+            BOOST_TEST(s >= l_s);
+        }
+
+        // const_string <=> string_view
+        {
+            SV eq_s = "test string";
+            SV l_s = "a";
+            SV g_s = "z";
+            BOOST_TEST(s == eq_s);
+            BOOST_TEST(!(s == l_s));
+            BOOST_TEST(!(s == g_s));
+            BOOST_TEST(!(s != eq_s));
+            BOOST_TEST(s != l_s);
+            BOOST_TEST(s != g_s);
+            BOOST_TEST(!(s < eq_s));
+            BOOST_TEST(s < g_s);
+            BOOST_TEST(!(s < l_s));
+            BOOST_TEST(s <= eq_s);
+            BOOST_TEST(s <= g_s);
+            BOOST_TEST(!(s <= l_s));
+            BOOST_TEST(!(s > eq_s));
+            BOOST_TEST(!(s > g_s));
+            BOOST_TEST(s > l_s);
+            BOOST_TEST(s >= eq_s);
+            BOOST_TEST(!(s >= g_s));
+            BOOST_TEST(s >= l_s);
+        }
+
+        // string_view <=> const_string
+        {
+            SV eq_s = "test string";
+            SV l_s = "a";
+            SV g_s = "z";
+            BOOST_TEST(eq_s == s);
+            BOOST_TEST(!(l_s == s));
+            BOOST_TEST(!(g_s == s));
+            BOOST_TEST(!(eq_s != s));
+            BOOST_TEST(l_s != s);
+            BOOST_TEST(g_s != s);
+            BOOST_TEST(!(eq_s < s));
+            BOOST_TEST(!(g_s < s));
+            BOOST_TEST(l_s < s);
+            BOOST_TEST(eq_s <= s);
+            BOOST_TEST(!(g_s <= s));
+            BOOST_TEST(l_s <= s);
+            BOOST_TEST(!(eq_s > s));
+            BOOST_TEST(g_s > s);
+            BOOST_TEST(!(l_s > s));
+            BOOST_TEST(eq_s >= s);
+            BOOST_TEST(g_s >= s);
+            BOOST_TEST(!(l_s >= s));
+        }
+    }
+
     void
     run()
     {
         testConstString();
         testFactory();
+        testSvFunctions<boost::core::string_view>();
+#ifndef BOOST_URL_NO_CXX17_HDR_STRING_VIEW
+        testSvFunctions<std::string_view>();
+#endif
     }
 };
 


### PR DESCRIPTION
This PR implements `operator string_view()` for `const_string` and removes `string_view` as a base class of `const_string`.

Benefits:
- Removes a base class and its subset of functions in conflict with the semantics of `const_string`
- Functions from `string_view` that are in conflict with `const_string`, such as `remove_suffix`, are completely removed from the interface
- Documentation related to this undefined behavior for these functions are removed
- Users will not get warnings about slicing being unsafe when using `const_string`
- Enables future optimization where the pointer is not stored redundantly in the shared string and the base string_view
- Enables future optimization where the pointer is not stored redundantly in the base string_view while it's known to be the first position in the built-in buffer
- Enables future optimization where the size is not stored redundantly in the shared string and the base string_view
- Enables future optimization where the size does not take more memory than it needs for the maximum of 2048 characters  allowed in a URL

Drawbacks:
- There might be use cases that do not work without inheriting from `string_view`. No such use case has been found in the existing tests and new tests yet. The new tests do include implicit conversion tests to functions that accept both string_view or std::string.
